### PR TITLE
:recycle: Change UI of rm_sumcol() and rm_sumrow()

### DIFF
--- a/R/shapetools.R
+++ b/R/shapetools.R
@@ -51,32 +51,37 @@ unmerge_vert <- function(df, col, regex = ".+") {
 #' Remove summary rows from df
 #'
 #' @param key Regex to detect summary rows
-#' @param colname Name of the colmun contains key
+#' @param colpos Position of the colmun contains key
+#' @param regex If TRUE, \code{key} was recognized as regular expression
 #' @inheritParams make_rect
 #' @export
-rm_sumrow <- function(df, key, colname) {
-  colpos <- stringr::str_which(df[1, ], colname)
+rm_sumrow <- function(df, key, colpos, regex) {
   target <- dplyr::pull(df, colpos)
-  df[-stringr::str_which(target, key), ]
+  if (regex) {
+    df[-stringr::str_which(target, key), ]
+  } else {
+    key_noregex <- paste0("^", key, "$")
+    df[-stringr::str_which(target, key_noregex), ]
+  }
 }
 
 #' Remove summary cols from df
 #'
 #' @param key Regex to detect summary cols
-#' @param rowname Name of the row contains key
-#' @param regex If TRUE, rowname was recognized by regular expression
+#' @param rowpos Position of the row contains key
+#' @param regex If TRUE, \code{rowname} was recognized as regular expression
 #' @inheritParams make_rect
 #' @export
-rm_sumcol <- function(df, key, rowname, regex = FALSE) {
-  if (regex == TRUE) {
-    rowpos <- stringr::str_which(dplyr::pull(df, 1), rowname)
-  } else {
-    rowpos <- which(df[, 1] == rowname)
-  }
+rm_sumcol <- function(df, key, rowpos, regex) {
   target <- dplyr::slice(df, rowpos) %>%
     unlist() %>%
     as.vector()
-  df[, -stringr::str_which(target, key)]
+  if (regex) {
+    df[, -stringr::str_which(target, key)]
+  } else {
+    key_noregex <- paste0("^", key, "$")
+    df[, -stringr::str_which(target, pattern = key_noregex)]
+  }
 }
 
 #' Merge colnames of multiple rows

--- a/man/rm_sumcol.Rd
+++ b/man/rm_sumcol.Rd
@@ -4,16 +4,16 @@
 \alias{rm_sumcol}
 \title{Remove summary cols from df}
 \usage{
-rm_sumcol(df, key, rowname, regex = FALSE)
+rm_sumcol(df, key, rowpos, regex)
 }
 \arguments{
 \item{df}{Data frame to be processed}
 
 \item{key}{Regex to detect summary cols}
 
-\item{rowname}{Name of the row contains key}
+\item{rowpos}{Position of the row contains key}
 
-\item{regex}{If TRUE, rowname was recognized by regular expression}
+\item{regex}{If TRUE, \code{rowname} was recognized as regular expression}
 }
 \description{
 Remove summary cols from df

--- a/man/rm_sumrow.Rd
+++ b/man/rm_sumrow.Rd
@@ -4,14 +4,16 @@
 \alias{rm_sumrow}
 \title{Remove summary rows from df}
 \usage{
-rm_sumrow(df, key, colname)
+rm_sumrow(df, key, colpos, regex)
 }
 \arguments{
 \item{df}{Data frame to be processed}
 
 \item{key}{Regex to detect summary rows}
 
-\item{colname}{Name of the colmun contains key}
+\item{colpos}{Position of the colmun contains key}
+
+\item{regex}{If TRUE, \code{key} was recognized as regular expression}
 }
 \description{
 Remove summary rows from df

--- a/tests/testthat/test_shapetools.R
+++ b/tests/testthat/test_shapetools.R
@@ -30,21 +30,24 @@ test_that("unmerge_vert() fill NAs of merged rows", {
 
 test_that("rm_sumrow() remove summary rows from df", {
   contami <- load_alldata("colsum_contami.xlsx", sheet = "Sheet1")
-  expect_equal(rm_sumrow(contami, key = "sum", colname = "A1") %>%
+  expect_equal(rm_sumrow(contami, key = "sum", colpos = 1, regex = FALSE) %>%
+                 dplyr::pull(1),
+               c(paste0("A", c(1:10, 12:20, 22:30))))
+  expect_equal(rm_sumrow(contami, key = "s.m", colpos = 1, regex = TRUE) %>%
                  dplyr::pull(1),
                c(paste0("A", c(1:10, 12:20, 22:30))))
 })
 
 test_that("rm_sumcol() remove summary cols from df", {
   contami <- load_alldata("rowsum_contami.xlsx", sheet = "Sheet1")
-  expect_equal(rm_sumcol(contami, key = "sum", rowname = "A1") %>%
+  expect_equal(rm_sumcol(contami, key = "sum", rowpos = 1, regex = FALSE) %>%
                  dplyr::slice(1) %>%
                  unlist() %>%
                  as.vector(),
                c(paste0(LETTERS[1:8][c(-4, -7)], 1)))
 
-  expect_equal(rm_sumcol(contami, key = "sum",
-                         rowname = "A1$", regex = TRUE) %>%
+  expect_equal(rm_sumcol(contami, key = "su.",
+                         rowpos = 1, regex = TRUE) %>%
                  dplyr::slice(1) %>%
                  unlist() %>%
                  as.vector(),


### PR DESCRIPTION
Require row-(col-)position, not row-(col-)name.
Because this function may be used for data without row-(col-)name.