### PR TITLE
:white_check_mark: Fight with iwate using rebel_sheet()

### DIFF
--- a/R/rebel.R
+++ b/R/rebel.R
@@ -111,14 +111,24 @@ rebel_sheet <- function(sheet, path, row_merged = 0, col_merged = 0,
   }
   out
 
-
   if (!is.null(attributes$row_type)) {
+    if (attributes$row_type == "Y") {
+      colnames(out)[1] <- "year"
+      out <- dplyr::mutate(out, year = as.integer(year))
+    }
+  }
+
+  if (!is.null(attributes$col_type)) {
     out <- gather_cols(df = out,
                        regex = col_type$regex,
                        newname = col_type$newname,
                        varname = attributes$col_type$varname)
+    if (attributes$col_type$newname == "month") {
+      out <- dplyr::mutate(out, month = stringr::str_remove(month, "\\D") %>%
+                             as.integer())
+    }
   }
-  out
+  tibble::as_tibble(out)
 }
 
 #' Rebel against godly Excel workbook

--- a/R/rebel.R
+++ b/R/rebel.R
@@ -63,7 +63,8 @@ rebel_sheet <- function(sheet, path, row_merged = 0, col_merged = 0,
     info   <- cluster$info
     if (dir == "row") {
       out <- extract_clusters(df = out, regex = regex, col = pos,
-                              offset = offset, ends = ends, info = info)
+                              offset = offset, ends = ends, info = info)  %>%
+        lapply(make_ascii, row = pos)
     } else if (dir == "col") {
       out <- extract_clusters(df = out, regex = regex, row = pos,
                               offset = offset, ends = ends, info = info)

--- a/R/shapetools.R
+++ b/R/shapetools.R
@@ -241,7 +241,7 @@ rm_nacols <- function(df) {
 #'   Form should be like \code{ends = list(row = "2019", col = "[Dd]ecember$")}
 #' @param info Parameters to control \code{link{append_info}}
 extract_a_cluster <- function(pos.key, find_from, direction, df,
-                          offset = c(0, 0), ends, info = NULL) {
+                              offset = c(0, 0), ends, info = NULL) {
   rofst <- offset[1]
   cofst <- offset[2]
 

--- a/R/shapetools.R
+++ b/R/shapetools.R
@@ -208,8 +208,22 @@ headerize <- function(df, row) {
 #' @inheritParams make_rect
 #' @export
 rm_nacols <- function(df) {
-  napos <- !is.na(colnames(df))
-  df[, napos]
+  df_leftmost <- df[, 1]
+  df_right    <- df[, -1]
+  name_left   <- colnames(df)[1]
+  name_right  <- colnames(df)[-1]
+  not_na <- !stringr::str_detect(colnames(df_right), "^NA(.[1-9]+)?$")
+  if (length(not_na) == 0) {
+    df
+  } else {
+    not_na <- tidyr::replace_na(not_na, FALSE)
+    not_na
+    out <- cbind(df_leftmost, df_right[, not_na]) %>%
+      data.frame(stringsAsFactors = FALSE)
+    colnames(out) <- c(name_left, name_right[not_na])
+    out[, 1] <- as.character(out[, 1])
+    out
+  }
 }
 
 #' Extract a cluster from df using the keyword

--- a/tests/testthat/test_multitools.R
+++ b/tests/testthat/test_multitools.R
@@ -10,7 +10,7 @@ test_that("Fight with maiwashi sheet of aomori data", {
     lapply(headerize, row = 1) %>%
     purrr::invoke(rbind, .) %>%
     rm_nacols() %>%
-    gather_cols(regex = "(1|2)?[0-9]月",
+    gather_cols(regex = "1?[0-9]月",
                 newname = "month", varname = "catch")
   expect_equal(colnames(converted), c("年／月", "漁法", "month", "catch"))
   expect_equal(unique(converted$漁法), c("まき網漁業", "定置網漁業（底建網含む）"))

--- a/tests/testthat/test_rebel.R
+++ b/tests/testthat/test_rebel.R
@@ -47,8 +47,8 @@ test_that("rebel() beat up file with YrowMcol data", {
                                         varname = "given_varname"))
   expect_equal(colnames(beaten),
                c("year", "fname", "sheet", "month", "given_varname"))
-  expect_equal(unique(beaten$year), as.character(1969:2000))
-  expect_equal(unique(beaten$month), as.character(1:12))
+  expect_equal(unique(beaten$year), 1969:2000)
+  expect_equal(unique(beaten$month), 1:12)
   expect_setequal(unique(beaten$given_varname), as.character(c(1:384, 401:784)))
 })
 

--- a/tests/testthat/test_rebel_prefec.R
+++ b/tests/testthat/test_rebel_prefec.R
@@ -53,3 +53,26 @@ test_that("rebel_sheet() beat aomori data up", {
   expect_equal(unique(katakuchi$fname), fname)
   expect_equal(unique(katakuchi$sheet), sheet)
 })
+
+test_that("rebel_sheet() beat iwate data up", {
+  fname <- "iwate.xls"
+  sheet <- "マイワシ"
+  year  <- 2018
+  row_regex <- paste0("^", 2018)
+
+  maiwashi <- rebel_sheet(path = fname, sheet = sheet,
+                          cluster = list(dir = "row",
+                                         pos = 1,
+                                         regex = ".+によるマイワシ.+",
+                                         offset = c(2, 0),
+                                         ends = list(row = row_regex,
+                                                     col = "(1|１)(2|２)月")),
+                          row_type = "Y",
+                          col_type = list(regex = "^1?[0-9]月",
+                                          newname = "month",
+                                          varname = "catch"))
+
+  expect_equal(unique(maiwashi$year), 1968:2018)
+  expect_equal(unique(maiwashi$month), 1:12)
+  expect_setequal(unique(maiwashi$catch), as.character(1:1224))
+})

--- a/tests/testthat/test_rebel_prefec.R
+++ b/tests/testthat/test_rebel_prefec.R
@@ -20,8 +20,8 @@ test_that("rebel_sheet() beat aomori data up", {
                                         newname = "month",
                                         varname = "catch"))
   expect_setequal(maiwashi$catch, as.character(1:936))
-  expect_equal(unique(maiwashi$month), paste0(1:12, "月"))
-  expect_equal(unique(maiwashi$`年／月`), as.character(1981:2019))
+  expect_equal(unique(maiwashi$month), 1:12)
+  expect_equal(unique(maiwashi$year), 1981:2019)
   expect_equal(unique(maiwashi$漁法), c("まき網漁業", "定置網漁業（底建網含む）"))
   expect_equal(unique(maiwashi$fname), fname)
   expect_equal(unique(maiwashi$sheet), sheet)
@@ -42,8 +42,8 @@ test_that("rebel_sheet() beat aomori data up", {
                                         newname = "month",
                                         varname = "catch"))
   expect_setequal(katakuchi$catch, as.character(1:936))
-  expect_equal(unique(katakuchi$month), paste0(1:12, "月"))
-  expect_equal(unique(katakuchi$`年／月`), as.character(1981:2019))
+  expect_equal(unique(katakuchi$month), 1:12)
+  expect_equal(unique(katakuchi$year), 1981:2019)
   expect_equal(unique(katakuchi$漁法), c("まき網漁業", "定置網漁業（底建網含む）"))
   expect_equal(unique(katakuchi$fname), fname)
   expect_equal(unique(katakuchi$sheet), sheet)

--- a/tests/testthat/test_rebel_prefec.R
+++ b/tests/testthat/test_rebel_prefec.R
@@ -19,6 +19,11 @@ test_that("rebel_sheet() beat aomori data up", {
                         col_type = list(regex = "^1?[0-9]月?",
                                         newname = "month",
                                         varname = "catch"))
+  expect_equal(dplyr::filter(maiwashi, year == 1997, month == 6,
+                             漁法 == "定置網漁業（底建網含む）") %>%
+               dplyr::select(catch) %>%
+               vectorize_row(1),
+               "666")
   expect_setequal(maiwashi$catch, as.character(1:936))
   expect_equal(unique(maiwashi$month), 1:12)
   expect_equal(unique(maiwashi$year), 1981:2019)

--- a/tests/testthat/test_rebel_sheet.R
+++ b/tests/testthat/test_rebel_sheet.R
@@ -46,8 +46,8 @@ test_that("rebel_sheet() beat up file with YrowMcol data", {
                                         varname = "given_varname"))
   expect_equal(colnames(beaten),
                c("year", "fname", "sheet", "month", "given_varname"))
-  expect_equal(unique(beaten$year), as.character(1969:2000))
-  expect_equal(unique(beaten$month), as.character(1:12))
+  expect_equal(unique(beaten$year), 1969:2000)
+  expect_equal(unique(beaten$month), 1:12)
   expect_setequal(unique(beaten$given_varname), as.character(1:384))
 })
 

--- a/tests/testthat/test_rebel_sheet.R
+++ b/tests/testthat/test_rebel_sheet.R
@@ -28,11 +28,11 @@ test_that("rebel_sheet() beat up file with clustered data", {
                as.character(c(62, 63, 72, 73, 82, 83, 92, 93)))
 
   beaten <- rebel_sheet(path = "clustered.xlsx", sheet = "foo",
-                  cluster = list(dir = "col",
-                                 pos = 1,
-                                 regex = "b..",
-                                 offset = c(1, 2),
-                                 ends = list(row = "^.5", col = "test")))
+                        cluster = list(dir = "col",
+                                       pos = 1,
+                                       regex = "b..",
+                                       offset = c(1, 2),
+                                       ends = list(row = "^.5", col = "test")))
   expect_equal(colnames(beaten), c("a", "test", "fname", "sheet"))
   expect_equal(as.numeric(dplyr::pull(beaten, 1)), c(42:45, 52:55, 62:65))
   expect_equal(as.numeric(dplyr::pull(beaten, 2)), c(72:75, 82:85, 92:95))


### PR DESCRIPTION
In this revision, 

- Columns `year` and `month` are converted to integer
- Columns named as `NA.[1-9]+$` were removed (not only named as `^NA$`)
