### PR TITLE
:children_crossing: Enable preview in rebel()

### DIFF
--- a/R/rebel.R
+++ b/R/rebel.R
@@ -127,15 +127,16 @@ rebel <- function(path, sheet_regex, row_merged = 0, col_merged = 0,
                   cluster = NULL, row_type = NULL, col_type = NULL,
                   row_omit = NULL, col_omit = NULL,
                   unfiscalize = c(month_start = NULL, rule = NULL)) {
+
   sheets <- stringr::str_extract(readxl::excel_sheets(path), sheet_regex) %>%
     stats::na.omit()
-  out <- purrr::map_df(sheets, rebel_sheet, path = path,
-                       row_merged = row_merged,
-                       col_merged = col_merged,
-                       cluster = cluster,
-                       row_type = row_type,
-                       col_type = col_type,
-                       row_omit = row_omit, col_omit = col_omit,
-                       unfiscalize)
-  tibble::as_tibble(out)
+
+  out <- lapply(sheets, rebel_sheet, path = path,
+                row_merged = row_merged, col_merged = col_merged,
+                cluster = cluster, row_type = row_type, col_type = col_type,
+                row_omit = row_omit, col_omit = col_omit, unfiscalize) %>%
+          purrr::invoke(rbind, .)
+
+    if (is.null(cluster)) return(ceasefire(out, funcname = "cluster"))
+    tibble::as_tibble(out)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -4,27 +4,29 @@
 #' @param fname String to add df as column 'fname'
 #' @param sheet String to add df as column 'sheet'
 #' @export
-add_reference <- function(df, fname, sheet) {
+add_reference <- function(df, fname = NULL, sheet = NULL) {
+  if (is.null(fname) || is.null(sheet)) return(df)
   dplyr::mutate(df, fname = fname, sheet = sheet)
 }
 
 #' Make df with reference for early return
 #'
 #' @param df Data frame to return
-#' @param path File path to be used by \code{add_reference}
+#' @param fname File path to be used by \code{add_reference}
 #' @param sheet Sheet name to be used by \code{add_reference}
 #' @param funcname Name of function to create message for user
 #' @param posnames If TRUE, row- and col- names are set to 'pos=' format for
 #' following cluster extraction
-ceasefire <- function(df, path, sheet, funcname, posnames = TRUE) {
+ceasefire <- function(df, fname = NULL, sheet = NULL,
+                      funcname, posnames = TRUE) {
   message(paste0("Good. Specify '", funcname, "' next."))
   if (posnames == TRUE) {
     df %>%
       magrittr::set_colnames(paste0("(dir='v',pos=", 1:ncol(df), ")")) %>%
-      add_reference(path, sheet) %>%
+      add_reference(fname, sheet) %>%
       as.data.frame() %>%
       magrittr::set_rownames(paste0("(dir='h',pos=", 1:nrow(df), ")"))
   } else {
-    add_reference(df, path, sheet)
+    add_reference(df, fname, sheet)
   }
 }

--- a/man/add_reference.Rd
+++ b/man/add_reference.Rd
@@ -4,7 +4,7 @@
 \alias{add_reference}
 \title{Add columns 'fname' and 'sheet' to df}
 \usage{
-add_reference(df, fname, sheet)
+add_reference(df, fname = NULL, sheet = NULL)
 }
 \arguments{
 \item{df}{Data frame to be processed}

--- a/man/ceasefire.Rd
+++ b/man/ceasefire.Rd
@@ -4,12 +4,12 @@
 \alias{ceasefire}
 \title{Make df with reference for early return}
 \usage{
-ceasefire(df, path, sheet, funcname, posnames = TRUE)
+ceasefire(df, fname = NULL, sheet = NULL, funcname, posnames = TRUE)
 }
 \arguments{
 \item{df}{Data frame to return}
 
-\item{path}{File path to be used by \code{add_reference}}
+\item{fname}{File path to be used by \code{add_reference}}
 
 \item{sheet}{Sheet name to be used by \code{add_reference}}
 

--- a/tests/testthat/test_rebel.R
+++ b/tests/testthat/test_rebel.R
@@ -127,3 +127,9 @@ test_that("rebel() beat up file contaminated by summary column", {
                c(paste0(LETTERS[c(1:3, 5:6, 8)], 1), "fname", "sheet"))
   expect_setequal(dplyr::pull(beaten, 2), as.character(c(2:30, 212:240)))
 })
+
+test_that("early return", {
+ returned <- rebel(path = "sumcol_contami.xlsx", sheet_regex = "Sheet.")
+  expect_equal(colnames(returned)[1:3], paste0("(dir='v',pos=", 1:3, ")"))
+  expect_equal(rownames(returned)[1:3], paste0("(dir='h',pos=", 1:3, ")"))
+})

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -12,7 +12,7 @@ test_that("add_reference() add 'fname' and 'sheet' columns to df", {
 test_that("ceasefire() returns massage and df", {
   df     <- data.frame(a = 1:5, b = 6:10)
   expect_message(
-    return <- ceasefire(df, path = "foo", sheet = "bar", funcname = "baz"),
+    return <- ceasefire(df, fname = "foo", sheet = "bar", funcname = "baz"),
     "Good. Specify 'baz' next."
   )
   expect_equal(colnames(return),
@@ -23,7 +23,7 @@ test_that("ceasefire() returns massage and df", {
   expect_equal(return[, 3], rep("foo", 5))
   expect_equal(return[, 4], rep("bar", 5))
 
-  return <- ceasefire(df, path = "foo", sheet = "bar",
+  return <- ceasefire(df, fname = "foo", sheet = "bar",
                       funcname = "baz", posnames = FALSE)
   expect_equal(colnames(return),
                c(letters[1:2], "fname", "sheet"))


### PR DESCRIPTION
:recycle: Use lapply() instead of purrr::map_df()

To enable rownames() for preview in early return

:recycle: Update argname

:bulb: Documentation

:white_check_mark: Add tests